### PR TITLE
Run criteria attaching prototype

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -9,6 +9,11 @@ fn main() {
         .insert_resource(Msaa { samples: 4 })
         .add_plugins(DefaultPlugins)
         .add_plugin(bevy_mod_picking::DefaultPickingPlugins)
+        .insert_resource(
+            bevy_transform_gizmo::TransformGizmoPluginConfig::with_run_criteria_producer(|| {
+                || bevy::ecs::schedule::ShouldRun::Yes
+            }),
+        )
         .add_plugin(bevy_transform_gizmo::TransformGizmoPlugin)
         .add_startup_system(setup.system())
         .run();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 use bevy::{
-    ecs::schedule::RunCriteriaDescriptorOrLabel, prelude::*, render::render_graph::base::MainPass,
+    ecs::schedule::{IntoRunCriteria, RunCriteriaDescriptorOrLabel},
+    prelude::*,
+    render::render_graph::base::MainPass,
     transform::TransformSystem,
 };
 use bevy_mod_picking::{self, PickingCamera, PickingSystem, Primitive3d, Selection};
@@ -35,11 +37,13 @@ pub struct TransformGizmoPluginConfig {
 }
 
 impl TransformGizmoPluginConfig {
-    pub fn with_run_criteria_producer(
-        run_criteria_producer: impl Fn() -> RunCriteriaDescriptorOrLabel + Send + Sync + 'static,
-    ) -> Self {
+    pub fn with_run_criteria_producer<F, C, M>(run_criteria_producer: F) -> Self
+    where
+        F: Fn() -> C + Send + Sync + 'static,
+        C: IntoRunCriteria<M>,
+    {
         Self {
-            run_criteria_producer: Box::new(run_criteria_producer),
+            run_criteria_producer: Box::new(move || run_criteria_producer().into()),
         }
     }
 }

--- a/src/normalization.rs
+++ b/src/normalization.rs
@@ -1,3 +1,4 @@
+use crate::TransformGizmoPluginConfig;
 use bevy::{prelude::*, render::camera::Camera, transform::TransformSystem};
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
@@ -8,13 +9,17 @@ pub enum FseNormalizeSystem {
 pub struct Ui3dNormalization;
 impl Plugin for Ui3dNormalization {
     fn build(&self, app: &mut App) {
-        app.add_system_to_stage(
-            CoreStage::PostUpdate,
-            normalize
-                .system()
-                .label(FseNormalizeSystem::Normalize)
-                .before(TransformSystem::TransformPropagate),
-        );
+        let mut system = normalize
+            .system()
+            .label(FseNormalizeSystem::Normalize)
+            .before(TransformSystem::TransformPropagate);
+        if let Some(TransformGizmoPluginConfig {
+            run_criteria_producer,
+        }) = app.world.get_resource()
+        {
+            system = system.with_run_criteria(run_criteria_producer());
+        }
+        app.add_system_to_stage(CoreStage::PostUpdate, system);
     }
 }
 


### PR DESCRIPTION
This is not inteded to be merged as is.

A rough prototype of how to let users attach their own run criteria to systems of the plugin - this is the building block that lets enabling/disabling the plugin via user-defined states. I haven't considered if the criteria even make sense on all of these systems.

The main hurdle in the way of making this less gnarly is that Bevy's run criteria (and thus states) are stage-specific. [Plans](https://github.com/bevyengine/rfcs/pull/29) to mitigate that do exist, but aren't quite ready yet; resolving this would make a single copy of a criteria (or label) sufficient for the entire config, instead of a producer function (aka bootleg clone).

Another thing I'm not sure if I like is that the nested plugins have to rely on the same config struct as the top-level plugin. This might be possible to rework, but I don't know how valuable would that be in this context.