### PR TITLE
[fix] Cancel gizmos' casting-shadow.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,11 @@ documentation = "https://docs.rs/bevy_transform_gizmo"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
-    "render",
-] }
-bevy_mod_picking = { git = "https://github.com/aevyrie/bevy_mod_picking", branch = "main" }
-bevy_mod_raycast = { git = "https://github.com/aevyrie/bevy_mod_raycast", branch = "main" }
+bevy = "0.6"
+bevy_mod_picking = "0.5"
+bevy_mod_raycast = "0.3"
 
 [dependencies.naga]
 features = ["wgsl-in", "spv-out", "wgsl-out"]
 version = "0.8"
 
-[dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
-    "bevy_winit",
-    "x11",
-] }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,9 +1,8 @@
-use bevy::{prelude::*, window::PresentMode};
+use bevy::prelude::*;
 
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            present_mode: PresentMode::Immediate, // Remove vsync as a source of input latency
             ..Default::default()
         })
         .insert_resource(Msaa { samples: 4 })

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -1,7 +1,10 @@
 use crate::{
     gizmo_material::GizmoMaterial, PickableGizmo, TransformGizmoBundle, TransformGizmoInteraction,
 };
-use bevy::prelude::*;
+use bevy::{
+    prelude::*,
+    pbr::{NotShadowCaster, NotShadowReceiver},
+};
 
 mod cone;
 mod truncated_torus;
@@ -96,7 +99,8 @@ pub fn build_gizmo(
                 .insert(TransformGizmoInteraction::TranslateAxis {
                     original: Vec3::X,
                     axis: Vec3::X,
-                });
+                })
+                .insert(NotShadowCaster);
             parent
                 .spawn_bundle(MaterialMeshBundle {
                     mesh: cone_mesh.clone(),
@@ -108,7 +112,8 @@ pub fn build_gizmo(
                 .insert(TransformGizmoInteraction::TranslateAxis {
                     original: Vec3::Y,
                     axis: Vec3::Y,
-                });
+                })
+                .insert(NotShadowCaster);
             parent
                 .spawn_bundle(MaterialMeshBundle {
                     mesh: cone_mesh.clone(),
@@ -123,7 +128,8 @@ pub fn build_gizmo(
                 .insert(TransformGizmoInteraction::TranslateAxis {
                     original: Vec3::Z,
                     axis: Vec3::Z,
-                });
+                })
+                .insert(NotShadowCaster);
             /*
                         // Origin
                         parent
@@ -176,7 +182,8 @@ pub fn build_gizmo(
                 .insert(TransformGizmoInteraction::RotateAxis {
                     original: Vec3::X,
                     axis: Vec3::X,
-                });
+                })
+                .insert(NotShadowCaster);
             parent
                 .spawn_bundle(MaterialMeshBundle {
                     mesh: sphere_mesh.clone(),
@@ -192,7 +199,8 @@ pub fn build_gizmo(
                 .insert(TransformGizmoInteraction::RotateAxis {
                     original: Vec3::Y,
                     axis: Vec3::Y,
-                });
+                })
+                .insert(NotShadowCaster);
             parent
                 .spawn_bundle(MaterialMeshBundle {
                     mesh: sphere_mesh.clone(),
@@ -208,7 +216,8 @@ pub fn build_gizmo(
                 .insert(TransformGizmoInteraction::RotateAxis {
                     original: Vec3::Z,
                     axis: Vec3::Z,
-                });
+                })
+                .insert(NotShadowCaster);
             /*
                         // Scaling Handles
                         parent

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use bevy::{
     prelude::*,
-    pbr::{NotShadowCaster, NotShadowReceiver},
+    pbr::NotShadowCaster,
 };
 
 mod cone;
@@ -64,7 +64,8 @@ pub fn build_gizmo(
                     Vec3::new(axis_length / 2.0, 0.0, 0.0),
                 )),
                 ..Default::default()
-            });
+            })
+            .insert(NotShadowCaster);
             parent.spawn_bundle(MaterialMeshBundle {
                 mesh: arrow_tail_mesh.clone(),
                 material: gizmo_matl_y.clone(),
@@ -73,7 +74,8 @@ pub fn build_gizmo(
                     Vec3::new(0.0, axis_length / 2.0, 0.0),
                 )),
                 ..Default::default()
-            });
+            })
+            .insert(NotShadowCaster);
             parent.spawn_bundle(MaterialMeshBundle {
                 mesh: arrow_tail_mesh,
                 material: gizmo_matl_z.clone(),
@@ -82,7 +84,8 @@ pub fn build_gizmo(
                     Vec3::new(0.0, 0.0, axis_length / 2.0),
                 )),
                 ..Default::default()
-            });
+            })
+            .insert(NotShadowCaster);
 
             // Translation Handles
             parent
@@ -150,12 +153,14 @@ pub fn build_gizmo(
                     f32::to_radians(90.0),
                 )),
                 ..Default::default()
-            });
+            })
+            .insert(NotShadowCaster);
             parent.spawn_bundle(MaterialMeshBundle {
                 mesh: rotation_mesh.clone(),
                 material: gizmo_matl_y.clone(),
                 ..Default::default()
-            });
+            })
+            .insert(NotShadowCaster);
             parent.spawn_bundle(MaterialMeshBundle {
                 mesh: rotation_mesh.clone(),
                 material: gizmo_matl_z.clone(),
@@ -164,7 +169,8 @@ pub fn build_gizmo(
                         * Quat::from_axis_angle(Vec3::X, f32::to_radians(90.0)),
                 ),
                 ..Default::default()
-            });
+            })
+            .insert(NotShadowCaster);
 
             // Rotation Handles
             parent


### PR DESCRIPTION
Add `pbr::NotShadowCaster` to every parts of the gizmos, to prevent them from casting shadows.