### PR TITLE
Avoid spamming errors in unexpected situations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-fe
 ] }
 bevy_mod_picking = { git = "https://github.com/aevyrie/bevy_mod_picking", branch = "main" }
 bevy_mod_raycast = { git = "https://github.com/aevyrie/bevy_mod_raycast", branch = "main" }
+thiserror = "1"
 
 [dependencies.naga]
 features = ["wgsl-in", "spv-out", "wgsl-out"]

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -349,6 +349,10 @@ pub fn build_gizmo(
 
     commands
         .spawn_bundle(Camera3dBundle {
+            camera: Camera {
+                is_active: false,
+                ..default()
+            },
             camera_3d: Camera3d {
                 clear_color: bevy::core_pipeline::clear_color::ClearColorConfig::None,
                 depth_load_op: bevy::core_pipeline::core_3d::Camera3dDepthLoadOp::Clear(0.),


### PR DESCRIPTION
Spamming errors greatly reduces the usability of a library, if every second, up to 500 errors are printed in the console, it is as good as if the library panicked.

With this PR, `bevy_transform_gizmo` will only log stuff if it didn't already emit a similar message within the last second. (note that I downgraded the errors into warnings, since they fundamentally do not break stuff)

I also use system chaining for logging, because of separation of concerns.