### PR TITLE
Fix shader bind group as noted in Bevy PR #10485

### DIFF
--- a/src/gizmo_material.wgsl
+++ b/src/gizmo_material.wgsl
@@ -4,7 +4,7 @@ struct GizmoMaterial {
     color: vec4<f32>,
 };
 
-@group(1) @binding(0)
+@group(2) @binding(0)
 var<uniform> material: GizmoMaterial;
 
 struct Vertex {


### PR DESCRIPTION
This should fix the wgpu panic in PR #64 for Bevy 0.13